### PR TITLE
Add AA batch output file, simplify output filenames, and add positional average to batch heatmap

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,27 @@
+name: PR Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e . pytest
+
+      - name: Run pytest
+        run: pytest

--- a/docs/batch_processing.md
+++ b/docs/batch_processing.md
@@ -152,11 +152,12 @@ Specify your own list of pathogenic control variants.
 Batch processing generates:
 
 ### Score Files
-- `batch_scores_[suffix].csv`: Combined normalized scores with batch tracking
-- `batch_stats_[suffix].json`: Comprehensive statistics and normalization factors
+- `batch_scores.csv`: Combined normalized scores with batch tracking
+- `batch_aa_scores.csv`: Combined amino acid level normalized scores when AA aggregation is available
+- `batch_stats.json`: Comprehensive statistics and normalization factors
 
 ### Visualizations  
 - Unified scaling: Single colorbar applies to all data  
 - Automatic sizing: Figure dimensions scale with position range
-`tiled_heatmap_[suffix].png`: Combined heatmap with position mapping
-`tiled_heatmap_[suffix]_matrix.csv`: Underlying matrix data for heatmap
+`tiled_heatmap.png`: Combined heatmap with position mapping
+`tiled_heatmap_matrix.csv`: Underlying matrix data for heatmap

--- a/docs/cli_arguments.md
+++ b/docs/cli_arguments.md
@@ -25,7 +25,6 @@ sortscore score [options]
 | `--min-pos` | - | int | Minimum position (1-based) | 1 |
 | `--max-pos` | - | int | Maximum position (1-based) | None |
 | `--relative-path-base` | - | str | Base directory for resolving relative paths when this setting is applied: `setup` or `cwd` | setup |
-| `--suffix` | `-s` | str | Custom suffix for all output files | (auto: current date) |
 | `--pos-color` | `-p` | flag | See [visualization.md](visualization.md) for exporting positional averages with colors for protein structure visualization | False |
 | `--fig-format` | - | str | Output format for figures: png, svg, pdf | png |
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -110,19 +110,15 @@ See [docs/cli_arguments.md](cli_arguments.md) for a complete list of command lin
 **Current Implementation:**
 ```
 # Score files
-scores/{experiment_name}_dna_scores_{suffix}.csv
-scores/{experiment_name}_aa_scores_{suffix}.csv
-# TODO: #31 add SNV functionality and test
-scores/{experiment_name}_dna_scores_snv_{suffix}.csv
+scores/{experiment_name}_dna_scores.csv
+scores/{experiment_name}_aa_scores.csv
 
 # Summary statistics
-scores/{experiment_name}_dna_stats_{suffix}.json         # when DNA scores are produced
-scores/{experiment_name}_aa_stats_{suffix}.json
+scores/{experiment_name}_dna_stats.json         # when DNA scores are produced
+scores/{experiment_name}_aa_stats.json
 
 # For a list of all visualization output files, see [visualization.md](visualization.md).
 ```
-
-**Auto-generated suffix format:** `YYYYMMDD` (current date)
 
 ### Examples
 
@@ -133,10 +129,6 @@ sortscore score -n my_experiment -e experiment_setup.csv -c my_experiment.json
 ```bash
 # DNA codon-level analysis
 sortscore score -n my_experiment -e experiment_setup.csv -c my_experiment.json --mutagenesis-type codon
-```
-```bash
-# With custom output suffix
-sortscore score -n my_experiment -e experiment_setup.csv -c my_experiment.json -s "final_analysis"
 ```
 ```bash
 # Generate SVG figures

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,8 +1,8 @@
 # Visualization files
-figures/{experiment_name}_aa_heatmap_{suffix}.{png|svg|pdf}
-figures/{experiment_name}_aa_heatmap_matrix_{suffix}.csv
-figures/{experiment_name}_codon_heatmap_{suffix}.{png|svg|pdf}         # when plotting DNA-level scores
-figures/{experiment_name}_codon_heatmap_matrix_{suffix}.csv            # when plotting DNA-level scores
+figures/{experiment_name}_aa_heatmap.{png|svg|pdf}
+figures/{experiment_name}_aa_heatmap_matrix.csv
+figures/{experiment_name}_codon_heatmap.{png|svg|pdf}         # when plotting DNA-level scores
+figures/{experiment_name}_codon_heatmap_matrix.csv            # when plotting DNA-level scores
 ### Exporting positional averages for structure visualization
 
 To export positional averages with hex color codes for protein structure visualization, use the `--pos-color` (or `-p`) flag:
@@ -14,7 +14,7 @@ sortscore score -n my_experiment -e experiment_setup.csv -c my_experiment.json -
 This generates a file:
 
 ```
-figures/{experiment_name}_positional_averages_{suffix}.csv
+figures/{experiment_name}_positional_averages.csv
 ```
 
 The file contains columns for position, average score, and a hex color suitable for mapping onto protein structures.
@@ -26,20 +26,9 @@ This guide covers heatmap generation, output formats, and visualization-specific
 
 When figures are produced, they are written under `figures/` in your output directory.
 
-Common files:
-
-```text
-figures/{experiment_name}_aa_heatmap_{suffix}.{png|svg|pdf}
-figures/{experiment_name}_aa_heatmap_matrix_{suffix}.csv
-figures/{experiment_name}_codon_heatmap_{suffix}.{png|svg|pdf}
-figures/{experiment_name}_codon_heatmap_matrix_{suffix}.csv
-figures/{experiment_name}_positional_averages_{suffix}.csv
-```
 
 Notes:
-
 - Codon heatmap files are produced when DNA-level scores are plotted.
-- `positional_averages` is produced when `--pos-color` is enabled.
 
 ## CLI options for visualization
 

--- a/sortscore/analysis/aa_scores.py
+++ b/sortscore/analysis/aa_scores.py
@@ -9,8 +9,15 @@ import logging
 import pandas as pd
 import numpy as np
 from scipy import stats as scipy_stats
-from typing import Tuple, List
+from typing import List
 from sortscore.analysis.statistics import calculate_codon_and_replicate_variance
+
+
+def _get_score_column_from_avg_method(avg_method: str) -> str:
+    """Return the score column name for a given averaging method."""
+    if avg_method == 'simple-avg':
+        return 'avgscore'
+    return f"avgscore_{avg_method.replace('-', '_')}"
 
 
 def process_and_save_aa_scores(scores_df: pd.DataFrame, experiment, scores_dir: str, 
@@ -45,26 +52,10 @@ def process_and_save_aa_scores(scores_df: pd.DataFrame, experiment, scores_dir: 
     """
     if 'aa_seq_diff' not in scores_df.columns:
         return
-        
-    # Determine score column
-    if experiment.avg_method == 'simple-avg':
-        score_col = 'avgscore'
-    else:
-        score_col_suffix = experiment.avg_method.replace('-', '_')
-        score_col = f'avgscore_{score_col_suffix}'
+
+    score_col = _get_score_column_from_avg_method(experiment.avg_method)
     
-    # Filter out rows with NaN values first
-    scores_df_drop_nan = scores_df.dropna(subset=[score_col])
-    
-    # Find replicate score columns
-    rep_score_columns = [col for col in scores_df_drop_nan.columns 
-                        if col.startswith('Rep') and col.endswith('.score')]
-    
-    # Check aggregation needs and process scores
-    aa_scores = _check_codon_num(scores_df_drop_nan, score_col, rep_score_columns)
-    
-    # Round score columns to integers
-    aa_scores = _round_score_columns(aa_scores)
+    aa_scores = build_aa_scores_table(scores_df, score_col)
     
     # Save to file
     aa_scores_file = os.path.join(scores_dir, f"{experiment.experiment_name}_aa_scores_{output_suffix}.csv")
@@ -78,6 +69,35 @@ def process_and_save_aa_scores(scores_df: pd.DataFrame, experiment, scores_dir: 
         aa_scores_file,
         variant_count=len(aa_scores)
     )
+
+
+def build_aa_scores_table(scores_df: pd.DataFrame, score_col: str) -> pd.DataFrame:
+    """
+    Build the AA-level score table from a scored variant table.
+
+    Parameters
+    ----------
+    scores_df : pd.DataFrame
+        DataFrame containing variant scores and annotations.
+    score_col : str
+        Score column used to determine which rows are retained and how codon
+        variance is calculated.
+
+    Returns
+    -------
+    pd.DataFrame
+        AA-level score table with synonymous codons aggregated when needed.
+    """
+    if 'aa_seq_diff' not in scores_df.columns:
+        raise ValueError("scores_df must contain 'aa_seq_diff' column for AA score output")
+
+    scores_df_drop_nan = scores_df.dropna(subset=[score_col])
+    rep_score_columns = [
+        col for col in scores_df_drop_nan.columns
+        if col.startswith('Rep') and col.endswith('.score')
+    ]
+    aa_scores = _check_codon_num(scores_df_drop_nan, score_col, rep_score_columns)
+    return _round_score_columns(aa_scores)
 
 
 def _check_codon_num(scores_df_drop_nan: pd.DataFrame, score_col: str, 

--- a/sortscore/analysis/aa_scores.py
+++ b/sortscore/analysis/aa_scores.py
@@ -20,8 +20,7 @@ def _get_score_column_from_avg_method(avg_method: str) -> str:
     return f"avgscore_{avg_method.replace('-', '_')}"
 
 
-def process_and_save_aa_scores(scores_df: pd.DataFrame, experiment, scores_dir: str, 
-                              output_suffix: str, analysis_logger) -> None:
+def process_and_save_aa_scores(scores_df: pd.DataFrame, experiment, scores_dir: str, analysis_logger) -> None:
     """
     Process and save amino acid scores from variant data.
     
@@ -41,8 +40,6 @@ def process_and_save_aa_scores(scores_df: pd.DataFrame, experiment, scores_dir: 
         Experiment configuration containing metadata
     scores_dir : str
         Directory to save scores file
-    output_suffix : str
-        Suffix for output filename
     analysis_logger : AnalysisLogger
         Logger instance for recording outputs
         
@@ -58,14 +55,14 @@ def process_and_save_aa_scores(scores_df: pd.DataFrame, experiment, scores_dir: 
     aa_scores = build_aa_scores_table(scores_df, score_col)
     
     # Save to file
-    aa_scores_file = os.path.join(scores_dir, f"{experiment.experiment_name}_aa_scores_{output_suffix}.csv")
+    aa_scores_file = os.path.join(scores_dir, f"{experiment.experiment_name}_aa_scores.csv")
     aa_scores.to_csv(aa_scores_file, index=False)
     logging.info(f"Saved AA scores to {aa_scores_file} ({len(aa_scores)} unique AA variants)")
     
     # Log file output  
     analysis_logger.log_output_file(
         'aa_scores',
-        f"{experiment.experiment_name}_aa_scores_{output_suffix}.csv", 
+        f"{experiment.experiment_name}_aa_scores.csv",
         aa_scores_file,
         variant_count=len(aa_scores)
     )

--- a/sortscore/analysis/batch_normalization.py
+++ b/sortscore/analysis/batch_normalization.py
@@ -101,8 +101,8 @@ def _load_scores_from_output_dir(output_dir: str) -> pd.DataFrame:
     if not scores_dir.exists():
         raise FileNotFoundError(f"Scores directory not found: {scores_dir}")
 
-    dna_files = sorted(scores_dir.glob("*_dna_scores_*.csv"))
-    aa_files = sorted(scores_dir.glob("*_aa_scores_*.csv"))
+    dna_files = sorted(scores_dir.glob("*_dna_scores.csv"))
+    aa_files = sorted(scores_dir.glob("*_aa_scores.csv"))
     candidate = None
     if dna_files:
         candidate = dna_files[-1]

--- a/sortscore/analysis/batch_normalization.py
+++ b/sortscore/analysis/batch_normalization.py
@@ -777,7 +777,6 @@ def generate_batch_visualizations(
     results: Dict[str, Any],
     batch_config: Dict[str, Any],
     output_dir: str,
-    suffix: Optional[str] = None
 ) -> None:
     """
     Generate tiled heatmap visualizations from batch results.
@@ -790,8 +789,6 @@ def generate_batch_visualizations(
         Batch configuration dictionary
     output_dir : str
         Output directory for visualizations
-    suffix : Optional[str]
-        Optional suffix for output files
     """
     from sortscore.analysis.batch_config import BatchConfig
     from sortscore.visualization.heatmaps import plot_tiled_heatmap
@@ -803,12 +800,6 @@ def generate_batch_visualizations(
     
     # Create batch config object for visualization
     config_obj = BatchConfig(**batch_config)
-    
-    # Generate suffix if not provided
-    if suffix is None:
-        timestamp = pd.Timestamp.now().strftime('%Y%m%d')
-        method = results['method']
-        suffix = f"batch_{method}_{timestamp}"
     
     # Determine score column to visualize
     score_col = 'avgscore'  # Default, could be made configurable
@@ -859,8 +850,8 @@ def generate_batch_visualizations(
         tick_values, tick_labels = _build_colorbar_ticks(results['normalized_scores'][score_col])
 
     # Create tiled heatmap
-    tiled_heatmap_file = os.path.join(figures_dir, f"tiled_heatmap_{suffix}.png")
-    combined_aa_heatmap_file = os.path.join(figures_dir, f"combined_aa_heatmap_{suffix}.png")
+    tiled_heatmap_file = os.path.join(figures_dir, "tiled_heatmap.png")
+    combined_aa_heatmap_file = os.path.join(figures_dir, "combined_aa_heatmap.png")
 
     try:
         plot_tiled_heatmap(
@@ -921,7 +912,6 @@ def generate_batch_visualizations(
 def save_batch_results(
     results: Dict[str, Any],
     output_dir: str,
-    suffix: Optional[str] = None
 ) -> None:
     """
     Save batch normalization results to files.
@@ -932,23 +922,15 @@ def save_batch_results(
         Results dictionary from batch analysis
     output_dir : str
         Output directory for saving results
-    suffix : Optional[str]
-        Optional suffix for output files
     """
     from sortscore.utils.file_utils import ensure_output_subdirs
     
     # Ensure output directories exist
     ensure_output_subdirs(output_dir)
     
-    # Generate suffix if not provided
-    if suffix is None:
-        timestamp = pd.Timestamp.now().strftime('%Y%m%d')
-        method = results['method']
-        suffix = f"batch_{method}_{timestamp}"
-    
     # Save normalized scores
     scores_dir = os.path.join(output_dir, 'scores')
-    scores_file = os.path.join(scores_dir, f"batch_scores_{suffix}.csv")
+    scores_file = os.path.join(scores_dir, "batch_scores.csv")
     
     normalized_scores = results['normalized_scores'].copy()
     # Round score columns to integers for consistency
@@ -964,12 +946,12 @@ def save_batch_results(
     if aa_scores is None:
         aa_scores = pd.DataFrame()
     if not aa_scores.empty:
-        aa_scores_file = os.path.join(scores_dir, f"batch_aa_scores_{suffix}.csv")
+        aa_scores_file = os.path.join(scores_dir, "batch_aa_scores.csv")
         aa_scores.to_csv(aa_scores_file, index=False)
         logger.info(f"Saved batch AA scores to {aa_scores_file}")
     
     # Save combined statistics
-    stats_file = os.path.join(scores_dir, f"batch_stats_{suffix}.json")
+    stats_file = os.path.join(scores_dir, "batch_stats.json")
     with open(stats_file, 'w') as f:
         json.dump(results['combined_stats'], f, indent=2)
     logger.info(f"Saved batch statistics to {stats_file}")

--- a/sortscore/analysis/batch_normalization.py
+++ b/sortscore/analysis/batch_normalization.py
@@ -22,9 +22,11 @@ from pathlib import Path
 from types import SimpleNamespace
 import pandas as pd
 import numpy as np
-from typing import Dict, List, Tuple, Optional, Any
+from typing import Dict, List, Tuple, Optional, Any, cast
 
 logger = logging.getLogger(__name__)
+
+from sortscore.analysis.aa_scores import _get_score_column_from_avg_method, build_aa_scores_table
 
 
 def _ensure_avgscore_column(scores_df: pd.DataFrame) -> pd.DataFrame:
@@ -54,6 +56,43 @@ def _coerce_score_columns_to_float(scores_df: pd.DataFrame) -> pd.DataFrame:
     for col in _score_columns(out):
         out[col] = pd.to_numeric(out[col], errors='coerce').astype(float)
     return out
+
+
+def _build_batch_aa_scores(
+    normalized_scores: pd.DataFrame,
+    experiments: List[Any],
+) -> pd.DataFrame:
+    """Aggregate normalized batch results to AA level for each batch separately."""
+
+    experiment_by_batch = {
+        f"tile{idx}": experiment
+        for idx, experiment in enumerate(experiments, start=1)
+    }
+
+    aa_batch_frames = []
+    for batch_name, batch_df in normalized_scores.groupby('batch'):
+        if 'aa_seq_diff' not in batch_df.columns:
+            continue
+
+        batch_name = cast(str, batch_name)
+        if batch_name not in experiment_by_batch:
+            raise ValueError(f"Missing experiment metadata for batch '{batch_name}'")
+        experiment = experiment_by_batch[batch_name]
+        score_col = _get_score_column_from_avg_method(experiment.avg_method)
+        if score_col not in batch_df.columns:
+            raise ValueError(
+                f"Batch '{batch_name}' is missing expected score column '{score_col}' "
+                f"for avg_method '{experiment.avg_method}'"
+            )
+
+        aa_df = build_aa_scores_table(batch_df, score_col)
+        aa_df['batch'] = batch_name
+        aa_batch_frames.append(aa_df)
+
+    if not aa_batch_frames:
+        return pd.DataFrame()
+
+    return pd.concat(aa_batch_frames, ignore_index=True)
 
 
 def _load_scores_from_output_dir(output_dir: str) -> pd.DataFrame:
@@ -130,7 +169,7 @@ def run_batch_analysis(batch_config: Dict[str, Any]) -> Dict[str, Any]:
             tile = int(cfg['tile'])
             output_dir_i = str(Path(str(cfg['output_dir'])).expanduser().resolve())
             scores_df = _load_scores_from_output_dir(output_dir_i)
-            batch_name = f"experiment{idx}"
+            batch_name = f"tile{idx}"
 
             mutagenesis_type = cfg.get('mutagenesis_type')
             if mutagenesis_type is None:
@@ -176,9 +215,11 @@ def run_batch_analysis(batch_config: Dict[str, Any]) -> Dict[str, Any]:
         raise ValueError(f"Unknown normalization method: {method}")
     
     logger.info(f"Applied {method} normalization to {len(normalized_scores)} variants")
+    normalized_aa_scores = _build_batch_aa_scores(normalized_scores, experiments)
     
     return {
         'normalized_scores': normalized_scores,
+        'normalized_aa_scores': normalized_aa_scores,
         'combined_stats': combined_stats,
         'method': method,
         'experiments': experiments,
@@ -696,6 +737,13 @@ def recalculate_final_statistics(
             final_stats['all_avg_global_final'] = float(scores.mean())
             final_stats['all_min_global_final'] = float(scores.min())
             final_stats['all_max_global_final'] = float(scores.max())
+
+    if 'annotate_aa' in normalized_scores.columns and score_col in normalized_scores.columns:
+        nonsense_subset = normalized_scores[normalized_scores['annotate_aa'] == 'nonsense']
+        if len(nonsense_subset) > 0:
+            nonsense_scores = nonsense_subset[score_col].dropna()
+            if len(nonsense_scores) > 0:
+                final_stats['nonsense_avg_global_final'] = float(nonsense_scores.mean())
     
     # Per-batch final statistics
     for batch_name, batch_df in normalized_scores.groupby('batch'):
@@ -788,7 +836,7 @@ def generate_batch_visualizations(
 
         pathogenic_tick = None
         if config_obj.pathogenic_control_type == 'nonsense':
-            pathogenic_tick = combined_stats.get('nonsense_avg_experiment1_final')
+            pathogenic_tick = combined_stats.get('nonsense_avg_global_final')
         if pathogenic_tick is None:
             pathogenic_tick = combined_stats.get('non_avg_global_zscore_z')
 
@@ -831,49 +879,40 @@ def generate_batch_visualizations(
         logger.info(f"Generated tiled heatmap: {tiled_heatmap_file}")
 
         # Also export a combined AA heatmap artifact for batch outputs.
-        from sortscore.analysis.variant_aggregation import aggregate_aa_data
+        aa_batch_data = results['normalized_aa_scores']
+        if not aa_batch_data.empty:
+            aa_tick_values = tick_values
+            aa_tick_labels = tick_labels
+            if score_col in aa_batch_data.columns:
+                aa_tick_values, aa_tick_labels = _build_colorbar_ticks(aa_batch_data[score_col])
+            aa_experiments = [
+                SimpleNamespace(
+                    tile=exp.tile,
+                    wt_seq=exp.wt_seq,
+                    mutagenesis_type='aa',
+                    avg_method=exp.avg_method,
+                    min_pos=exp.min_pos,
+                    max_pos=exp.max_pos,
+                    mutagenesis_variants=exp.mutagenesis_variants,
+                )
+                for exp in results['experiments']
+            ]
 
-        aa_batch_frames = []
-        for batch_name, batch_df in results['normalized_scores'].groupby('batch'):
-            if 'aa_seq_diff' not in batch_df.columns:
-                continue
-            aa_df = aggregate_aa_data(batch_df, score_col)
-            aa_df['batch'] = batch_name
-            aa_batch_frames.append(aa_df)
-
-        aa_batch_data = pd.concat(aa_batch_frames, ignore_index=True) if aa_batch_frames else results['normalized_scores']
-        aa_tick_values = tick_values
-        aa_tick_labels = tick_labels
-        if score_col in aa_batch_data.columns:
-            aa_tick_values, aa_tick_labels = _build_colorbar_ticks(aa_batch_data[score_col])
-        aa_experiments = [
-            SimpleNamespace(
-                tile=exp.tile,
-                wt_seq=exp.wt_seq,
-                mutagenesis_type='aa',
-                avg_method=exp.avg_method,
-                min_pos=exp.min_pos,
-                max_pos=exp.max_pos,
-                mutagenesis_variants=exp.mutagenesis_variants,
+            plot_tiled_heatmap(
+                batch_data=aa_batch_data,
+                score_col=score_col,
+                batch_config=config_obj,
+                experiments=aa_experiments,
+                wt_score=wt_score,
+                tick_values=aa_tick_values,
+                tick_labels=aa_tick_labels,
+                export=True,
+                output=combined_aa_heatmap_file,
+                export_matrix=True,
+                biophysical_properties=False,
+                title='Combined AA Heatmap'
             )
-            for exp in results['experiments']
-        ]
-
-        plot_tiled_heatmap(
-            batch_data=aa_batch_data,
-            score_col=score_col,
-            batch_config=config_obj,
-            experiments=aa_experiments,
-            wt_score=wt_score,
-            tick_values=aa_tick_values,
-            tick_labels=aa_tick_labels,
-            export=True,
-            output=combined_aa_heatmap_file,
-            export_matrix=True,
-            biophysical_properties=False,
-            title='Combined AA Heatmap'
-        )
-        logger.info(f"Generated combined AA heatmap: {combined_aa_heatmap_file}")
+            logger.info(f"Generated combined AA heatmap: {combined_aa_heatmap_file}")
 
     except Exception as e:
         logger.error(f"Failed to generate tiled/combined AA heatmap: {e}")
@@ -920,6 +959,14 @@ def save_batch_results(
     
     normalized_scores.to_csv(scores_file, index=False)
     logger.info(f"Saved batch scores to {scores_file}")
+
+    aa_scores = results.get('normalized_aa_scores')
+    if aa_scores is None:
+        aa_scores = pd.DataFrame()
+    if not aa_scores.empty:
+        aa_scores_file = os.path.join(scores_dir, f"batch_aa_scores_{suffix}.csv")
+        aa_scores.to_csv(aa_scores_file, index=False)
+        logger.info(f"Saved batch AA scores to {aa_scores_file}")
     
     # Save combined statistics
     stats_file = os.path.join(scores_dir, f"batch_stats_{suffix}.json")

--- a/sortscore/analysis/batch_workflow.py
+++ b/sortscore/analysis/batch_workflow.py
@@ -6,12 +6,11 @@ loading, analysis execution, result saving, and visualization generation.
 """
 import logging
 import sys
-from typing import Optional
 from sortscore.analysis.batch_config import BatchConfig
 from sortscore.analysis.batch_normalization import run_batch_analysis, save_batch_results, generate_batch_visualizations
 
 
-def run_batch_mode(config_path: str, suffix: Optional[str] = None) -> None:
+def run_batch_mode(config_path: str) -> None:
     """
     Run batch processing mode for combining multiple experiments.
     
@@ -26,13 +25,9 @@ def run_batch_mode(config_path: str, suffix: Optional[str] = None) -> None:
     ----------
     config_path : str
         Path to batch configuration JSON file
-    suffix : Optional[str]
-        Custom suffix for output files
-        
     Examples
     --------
     >>> run_batch_mode('batch_config.json')
-    >>> run_batch_mode('batch_config.json', suffix='final_analysis')
     """
     # Load batch configuration
     try:
@@ -54,7 +49,7 @@ def run_batch_mode(config_path: str, suffix: Optional[str] = None) -> None:
     
     # Save results
     try:
-        save_batch_results(results, results['output_dir'], suffix)
+        save_batch_results(results, results['output_dir'])
         logging.info(f"Batch results saved to {results['output_dir']}")
     except Exception as e:
         logging.error(f"Failed to save batch results: {e}")
@@ -65,8 +60,7 @@ def run_batch_mode(config_path: str, suffix: Optional[str] = None) -> None:
         generate_batch_visualizations(
             results, 
             batch_config_dict, 
-            results['output_dir'], 
-            suffix
+            results['output_dir']
         )
         logging.info("Generated batch visualizations")
     except Exception as e:

--- a/sortscore/analysis/summary_stats.py
+++ b/sortscore/analysis/summary_stats.py
@@ -120,7 +120,6 @@ def save_summary_stats(
     stats: Dict[str, Any],
     experiment,
     scores_dir: str,
-    output_suffix: str,
     analysis_logger,
     *,
     stats_basename: str = "stats",
@@ -138,8 +137,6 @@ def save_summary_stats(
         Experiment configuration
     scores_dir : str
         Directory to save stats file
-    output_suffix : str
-        Suffix for output filename
     analysis_logger : AnalysisLogger
         Logger instance for recording outputs
     stats_basename : str, optional
@@ -159,9 +156,9 @@ def save_summary_stats(
     Examples
     --------
     >>> stats = calculate_summary_stats(scores_df, experiment)
-    >>> stats_file = save_summary_stats(stats, experiment, 'output/scores', 'suffix', logger)
+    >>> stats_file = save_summary_stats(stats, experiment, 'output/scores', logger)
     """
-    stats_file = os.path.join(scores_dir, f"{experiment.experiment_name}_{stats_basename}_{output_suffix}.json")
+    stats_file = os.path.join(scores_dir, f"{experiment.experiment_name}_{stats_basename}.json")
     
     with open(stats_file, 'w') as f:
         json.dump(stats, f, indent=2)
@@ -174,7 +171,7 @@ def save_summary_stats(
 
     analysis_logger.log_output_file(
         output_field,
-        f"{experiment.experiment_name}_{stats_basename}_{output_suffix}.json",
+        f"{experiment.experiment_name}_{stats_basename}.json",
         stats_file,
         **metadata,
     )

--- a/sortscore/analysis/workflows.py
+++ b/sortscore/analysis/workflows.py
@@ -56,7 +56,7 @@ def calculate_variant_scores(experiment, merged_df: pd.DataFrame) -> pd.DataFram
     return scores_df
 
 
-def process_dna_workflow(experiment, output_dir: str, output_suffix: str, analysis_logger) -> Optional[str]:
+def process_dna_workflow(experiment, output_dir: str, analysis_logger) -> Optional[str]:
     """
     Process DNA-level analysis workflow (codon or snv analysis types).
     
@@ -66,8 +66,6 @@ def process_dna_workflow(experiment, output_dir: str, output_suffix: str, analys
         Experiment configuration
     output_dir : str
         Output directory
-    output_suffix : str
-        Output file suffix
     analysis_logger : AnalysisLogger
         Analysis logger
         
@@ -98,14 +96,14 @@ def process_dna_workflow(experiment, output_dir: str, output_suffix: str, analys
     scores_df_rounded = round_score_columns(scores_df_rounded)
     
     # Save DNA scores
-    dna_scores_file = os.path.join(scores_dir, f"{experiment.experiment_name}_dna_scores_{output_suffix}.csv")
+    dna_scores_file = os.path.join(scores_dir, f"{experiment.experiment_name}_dna_scores.csv")
     scores_df_rounded.to_csv(dna_scores_file, index=False)
     logging.info(f"Saved DNA scores to {dna_scores_file}")
     
     # Log output
     analysis_logger.log_output_file(
         'dna_scores', 
-        f"{experiment.experiment_name}_dna_scores_{output_suffix}.csv",
+        f"{experiment.experiment_name}_dna_scores.csv",
         dna_scores_file,
         variant_count=len(scores_df_rounded)
     )
@@ -116,7 +114,6 @@ def process_dna_workflow(experiment, output_dir: str, output_suffix: str, analys
         stats,
         experiment,
         scores_dir,
-        output_suffix,
         analysis_logger,
         stats_basename="dna_stats",
         output_field="dna_statistics",
@@ -126,7 +123,7 @@ def process_dna_workflow(experiment, output_dir: str, output_suffix: str, analys
     return dna_scores_file
 
 
-def process_aa_workflow(experiment, output_dir: str, output_suffix: str, analysis_logger, 
+def process_aa_workflow(experiment, output_dir: str, analysis_logger,
                        dna_scores_file: Optional[str] = None) -> str:
     """
     Process AA-level analysis workflow.
@@ -141,8 +138,6 @@ def process_aa_workflow(experiment, output_dir: str, output_suffix: str, analysi
         Experiment configuration
     output_dir : str
         Output directory
-    output_suffix : str
-        Output file suffix
     analysis_logger : AnalysisLogger
         Analysis logger
     dna_scores_file : Optional[str]
@@ -182,10 +177,10 @@ def process_aa_workflow(experiment, output_dir: str, output_suffix: str, analysi
         analysis_logger.set_processing_stats(len(scores_df))
     
     # Process and save AA scores using existing function
-    process_and_save_aa_scores(scores_df, experiment, scores_dir, output_suffix, analysis_logger)
+    process_and_save_aa_scores(scores_df, experiment, scores_dir, analysis_logger)
     
     # Calculate and save statistics on the final processed AA data
-    aa_scores_file = os.path.join(scores_dir, f"{experiment.experiment_name}_aa_scores_{output_suffix}.csv")
+    aa_scores_file = os.path.join(scores_dir, f"{experiment.experiment_name}_aa_scores.csv")
     
     if os.path.exists(aa_scores_file):
         final_scores_df = pd.read_csv(aa_scores_file)
@@ -194,7 +189,6 @@ def process_aa_workflow(experiment, output_dir: str, output_suffix: str, analysi
             stats,
             experiment,
             scores_dir,
-            output_suffix,
             analysis_logger,
             stats_basename="aa_stats",
             output_field="aa_statistics",
@@ -204,7 +198,7 @@ def process_aa_workflow(experiment, output_dir: str, output_suffix: str, analysi
     return aa_scores_file
 
 
-def run_variant_analysis_workflow(experiment, output_dir: str, output_suffix: str, analysis_logger) -> Tuple[Optional[str], str]:
+def run_variant_analysis_workflow(experiment, output_dir: str, analysis_logger) -> Tuple[Optional[str], str]:
     """
     Run the complete variant analysis workflow based on mutagenesis_type.
     
@@ -218,8 +212,6 @@ def run_variant_analysis_workflow(experiment, output_dir: str, output_suffix: st
         Experiment configuration
     output_dir : str
         Output directory
-    output_suffix : str
-        Output file suffix
     analysis_logger : AnalysisLogger
         Analysis logger
         
@@ -231,7 +223,7 @@ def run_variant_analysis_workflow(experiment, output_dir: str, output_suffix: st
     """
     logging.info(f"Using mutagenesis_type: '{experiment.mutagenesis_type}'")
     
-    dna_scores_file = process_dna_workflow(experiment, output_dir, output_suffix, analysis_logger)
-    aa_scores_file = process_aa_workflow(experiment, output_dir, output_suffix, analysis_logger, dna_scores_file)
+    dna_scores_file = process_dna_workflow(experiment, output_dir, analysis_logger)
+    aa_scores_file = process_aa_workflow(experiment, output_dir, analysis_logger, dna_scores_file)
     
     return dna_scores_file, aa_scores_file

--- a/sortscore/run_analysis.py
+++ b/sortscore/run_analysis.py
@@ -13,7 +13,7 @@ from typing import Optional, Dict, Any
 import pandas as pd
 from sortscore.utils.load_experiment import ExperimentConfig
 from sortscore.utils.file_utils import ensure_output_subdirs
-from sortscore.utils.analysis_logger import AnalysisLogger, generate_date_suffix
+from sortscore.utils.analysis_logger import AnalysisLogger
 from sortscore.analysis.workflows import run_variant_analysis_workflow
 from sortscore.visualization.heatmap_workflow import generate_heatmap_visualizations
 from sortscore.utils.console_utils import parse_analysis_args, build_merged_analysis_config
@@ -54,7 +54,6 @@ def _apply_experiment_overrides(base: Dict[str, Any], entry: Optional[Dict[str, 
 def _run_single_analysis(
     experiment: ExperimentConfig,
     args,
-    output_suffix: str,
     *,
     fail_on_viz_error: bool = True,
 ) -> None:
@@ -66,11 +65,11 @@ def _run_single_analysis(
     print("Counts loaded.")
 
     fig_format = getattr(args, 'fig_format', None) or getattr(experiment, 'fig_format', None) or 'png'
-    analysis_logger = AnalysisLogger(experiment, args, output_suffix, output_dir)
+    analysis_logger = AnalysisLogger(experiment, args, output_dir)
 
     try:
         dna_scores_file, aa_scores_file = run_variant_analysis_workflow(
-            experiment, output_dir, output_suffix, analysis_logger
+            experiment, output_dir, analysis_logger
         )
         dna_scores_df = pd.read_csv(dna_scores_file) if dna_scores_file and os.path.exists(dna_scores_file) else None
         aa_scores_df = pd.read_csv(aa_scores_file) if aa_scores_file and os.path.exists(aa_scores_file) else None
@@ -93,7 +92,6 @@ def _run_single_analysis(
                 scores_df=aa_scores_df,
                 experiment=experiment,
                 output_dir=output_dir,
-                output_suffix=output_suffix,
                 fig_format=fig_format,
                 export_positional_averages=args.pos_color,
             )
@@ -103,7 +101,6 @@ def _run_single_analysis(
                     scores_df=dna_scores_df,
                     experiment=experiment,
                     output_dir=output_dir,
-                    output_suffix=output_suffix,
                     fig_format=fig_format,
                     export_positional_averages=args.pos_color,
                 )
@@ -112,7 +109,6 @@ def _run_single_analysis(
                     scores_df=aa_scores_df,
                     experiment=experiment,
                     output_dir=output_dir,
-                    output_suffix=output_suffix,
                     fig_format=fig_format,
                     export_positional_averages=args.pos_color,
                 )
@@ -122,7 +118,6 @@ def _run_single_analysis(
                     scores_df=dna_scores_df,
                     experiment=experiment,
                     output_dir=output_dir,
-                    output_suffix=output_suffix,
                     fig_format=fig_format,
                     export_positional_averages=args.pos_color,
                 )
@@ -131,7 +126,6 @@ def _run_single_analysis(
                     scores_df=aa_scores_df,
                     experiment=experiment,
                     output_dir=output_dir,
-                    output_suffix=output_suffix,
                     fig_format=fig_format,
                     export_positional_averages=args.pos_color,
                 )
@@ -164,14 +158,6 @@ def main():
         logging.error(str(e))
         sys.exit(1)
 
-    # Generate string that will be used to name output files
-    if args.suffix:
-        output_suffix = args.suffix
-        logging.info(f"Using custom output suffix: {output_suffix}")
-    else:
-        output_suffix = generate_date_suffix()
-        logging.info(f"Using date-based output suffix: {output_suffix}")
-
     try:
         setup_df, setup_cols = load_experiment_setup(merged["experiment_setup_file"], require_tile=False)
     except Exception as e:
@@ -190,7 +176,7 @@ def main():
             entry = _select_experiment_entry(merged, tile=None)
             merged_single = _apply_experiment_overrides(merged, entry)
             experiment = ExperimentConfig.from_dict(merged_single, config_file_dir=config_dir)
-            _run_single_analysis(experiment, args, output_suffix, fail_on_viz_error=True)
+            _run_single_analysis(experiment, args, fail_on_viz_error=True)
         except Exception as e:
             logging.error(f"Failed to run analysis: {e}")
             sys.exit(1)
@@ -223,7 +209,7 @@ def main():
         logging.info(f"Running tile {tile}: output_dir={tile_merged['output_dir']}")
         try:
             experiment = ExperimentConfig.from_dict(tile_merged, config_file_dir=config_dir)
-            _run_single_analysis(experiment, args, output_suffix, fail_on_viz_error=True)
+            _run_single_analysis(experiment, args, fail_on_viz_error=True)
         except Exception as e:
             failures += 1
             logging.error(f"Tile {tile} failed: {e}")

--- a/sortscore/run_batch_analysis.py
+++ b/sortscore/run_batch_analysis.py
@@ -30,8 +30,6 @@ def main():
                        help='Override combined output directory from batch config JSON')
     parser.add_argument('--method', type=str, choices=['zscore_2pole', '2pole', 'zscore_center'],
                        help='Override normalization method from batch config JSON')
-    parser.add_argument('-s', '--suffix', type=str, 
-                       help='Custom suffix for output files (default: auto-generated)')
     args = parser.parse_args()
 
     # Load batch configuration
@@ -58,7 +56,7 @@ def main():
     
     # Save results
     try:
-        save_batch_results(results, results['output_dir'], args.suffix)
+        save_batch_results(results, results['output_dir'])
         logging.info(f"Batch results saved to {results['output_dir']}")
     except Exception as e:
         logging.error(f"Failed to save batch results: {e}")
@@ -69,8 +67,7 @@ def main():
         generate_batch_visualizations(
             results, 
             batch_config_dict, 
-            results['output_dir'], 
-            args.suffix
+            results['output_dir']
         )
         logging.info("Generated batch visualizations")
     except Exception as e:

--- a/sortscore/utils/analysis_logger.py
+++ b/sortscore/utils/analysis_logger.py
@@ -85,7 +85,7 @@ class AnalysisLogger:
     reproducibility.
     """
     
-    def __init__(self, experiment, args, output_suffix: str, output_dir: str):
+    def __init__(self, experiment, args, output_dir: str):
         """
         Initialize analysis logger with automatic parameter extraction.
         
@@ -95,18 +95,15 @@ class AnalysisLogger:
             Experiment configuration object
         args : argparse.Namespace
             Command-line arguments
-        output_suffix : str
-            Suffix for output files
         output_dir : str
             Output directory for analysis files
         """
         self.experiment_name = experiment.experiment_name
-        self.suffix = output_suffix
         self.output_dir = output_dir
         
         # Generate unique analysis ID
         timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        self.analysis_id = f"{experiment.experiment_name}_{output_suffix}_{timestamp}"
+        self.analysis_id = f"{experiment.experiment_name}_{timestamp}"
         
         # Initialize data structures
         self.execution = ExecutionInfo(
@@ -116,13 +113,12 @@ class AnalysisLogger:
         self.environment = self._capture_environment()
         
         # Log file path
-        self.log_file = os.path.join(output_dir, f"{experiment.experiment_name}_analysis_{output_suffix}.log.json")
+        self.log_file = os.path.join(output_dir, f"{experiment.experiment_name}_analysis.log.json")
         
         # Extract and set request parameters automatically
         # TODO: #36 resolve to experiment/execution parameters instead of CLI args
         cli_args = {
             'config': getattr(args, 'config', None),
-            'suffix': getattr(args, 'suffix', None),
             'batch': getattr(args, 'batch', False),
             'pos_color': getattr(args, 'pos_color', False),
             'fig_format': getattr(args, 'fig_format', None)
@@ -270,8 +266,3 @@ class AnalysisLogger:
         """Serialize outputs, filtering out None values."""
         outputs_dict = asdict(self.outputs)
         return {k: v for k, v in outputs_dict.items() if v is not None}
-
-
-def generate_date_suffix() -> str:
-    """Generate a date-based suffix for output files."""
-    return datetime.now().strftime('%Y%m%d')

--- a/sortscore/utils/console_utils.py
+++ b/sortscore/utils/console_utils.py
@@ -105,11 +105,6 @@ def create_analysis_parser() -> argparse.ArgumentParser:
                         required=False, 
                         help="Maximum position (1-based). If not provided, uses config value or default (None)."
                             )
-    parser.add_argument('-s', '--suffix', 
-                        type=str, 
-                        required=False,
-                        help='Custom suffix for output files. If not provided, uses date-based suffix (YYYYMMDD).'
-                            )
     parser.add_argument('-p', '--pos-color', 
                         action='store_true', 
                         help='Export positional averages with colors for protein structure visualization. If not provided, uses config value or default (False).'

--- a/sortscore/visualization/heatmap_workflow.py
+++ b/sortscore/visualization/heatmap_workflow.py
@@ -81,7 +81,6 @@ def generate_heatmap_visualizations(
     scores_df: pd.DataFrame,
     experiment: ExperimentConfig,
     output_dir: str,
-    output_suffix: str,
     fig_format: str = 'png',
     export_positional_averages: bool = False,
 ) -> None:
@@ -96,8 +95,6 @@ def generate_heatmap_visualizations(
         Experiment configuration used for plotting context.
     output_dir : str
         Base output directory (figures will be written under ``output_dir/figures``).
-    output_suffix : str
-        Suffix applied to exported file names for traceability.
     fig_format : str, optional
         Export figure format (default: ``'png'``).
     export_positional_averages : bool, optional
@@ -159,7 +156,6 @@ def generate_heatmap_visualizations(
             export_matrix=True,
             export_positional_averages=export_positional_averages,
             biophysical_properties=experiment.biophysical_prop,
-            suffix=output_suffix,
         )
 
         plot_heatmap(
@@ -172,7 +168,7 @@ def generate_heatmap_visualizations(
             **plot_kwargs,
         )
 
-        aa_heatmap_file = os.path.join(figures_dir, f"{experiment.experiment_name}_aa_heatmap_{output_suffix}.{fig_format}")
+        aa_heatmap_file = os.path.join(figures_dir, f"{experiment.experiment_name}_aa_heatmap.{fig_format}")
         logger.info("Saved AA heatmap to %s", aa_heatmap_file)
 
     # Codon heatmap generation (DNA-level plots only make sense when plotting DNA-level scores)
@@ -201,7 +197,6 @@ def generate_heatmap_visualizations(
             export_matrix=True,
             export_positional_averages=export_positional_averages,
             biophysical_properties=experiment.biophysical_prop,
-            suffix=output_suffix,
         )
 
         plot_heatmap(
@@ -214,5 +209,5 @@ def generate_heatmap_visualizations(
             **plot_kwargs,
         )
 
-        codon_heatmap_file = os.path.join(figures_dir, f"{experiment.experiment_name}_codon_heatmap_{output_suffix}.{fig_format}")
+        codon_heatmap_file = os.path.join(figures_dir, f"{experiment.experiment_name}_codon_heatmap.{fig_format}")
         logger.info("Saved codon heatmap to %s", codon_heatmap_file)

--- a/sortscore/visualization/heatmaps.py
+++ b/sortscore/visualization/heatmaps.py
@@ -32,6 +32,23 @@ from sortscore.analysis.batch_config import BatchConfig
 from sortscore.utils.sequence_parsing import convert_aa_to_three_letter
 
 
+def _is_codon_heatmap(num_rows: int) -> bool:
+    """Return True when the matrix has codon-level row density."""
+    return num_rows > 21
+
+
+def _is_aa_heatmap(num_rows: int) -> bool:
+    """Return True for standard AA heatmaps (20 amino acids plus stop)."""
+    return num_rows <= 21
+
+
+def _avg_main_height_ratios(*, row_avg: bool, is_codon_heatmap: bool) -> tuple[float, int]:
+    """Return GridSpec height ratios for the positional average row and main heatmap."""
+    if row_avg:
+        return (0.75, 60) if is_codon_heatmap else (1, 45)
+    return (0.75, 35) if is_codon_heatmap else (1, 20)
+
+
 def _add_biophysical_properties_panel(ax, row_labels, aa_boundaries, is_small_heatmap=False):
     """Add biophysical properties heatmap panel for amino acid groups in codon heatmaps."""
     
@@ -243,8 +260,8 @@ def plot_heatmap(
     
     # Determine if this is a codon heatmap and whether to show biophysical properties
     num_rows = len(dms_matrix.index)
-    is_codon_heatmap = num_rows > 21  # More than 21 rows = codon heatmap
-    is_small_aa_heatmap = num_rows == 21  # Exactly 21 rows = standard AA heatmap
+    is_codon_heatmap = _is_codon_heatmap(num_rows)
+    is_small_aa_heatmap = _is_aa_heatmap(num_rows)
     show_props = biophysical_properties and (is_codon_heatmap or is_small_aa_heatmap)
     
     # Configure figure size
@@ -267,19 +284,18 @@ def plot_heatmap(
         fig = plt.figure(figsize=(width, height), facecolor=facecolor)
         tick_freq = max(1, experiment.num_aa // 40)
 
+    avg_height_ratio, main_height_ratio = _avg_main_height_ratios(
+        row_avg=row_avg,
+        is_codon_heatmap=is_codon_heatmap,
+    )
+
     # Set up subplot layout based on row_avg and biophysical properties
     if row_avg:
         row_avg_df = pd.DataFrame(heatmap_df.mean(axis=1), columns=['Avg'])
-        if is_codon_heatmap:
-            avg_height_ratio = 0.75 
-            main_height_ratio = 60
-        else:
-            avg_height_ratio = 1
-            main_height_ratio = 45
             
         if show_props:
             # Add space for biophysical properties panel
-            gs = GridSpec(2,5, width_ratios=[1, 35, 5, 1, 1], height_ratios=[avg_height_ratio, main_height_ratio], hspace=0.03, wspace=0.05)
+            gs = GridSpec(2,4, width_ratios=[1, 35, 5, 1], height_ratios=[avg_height_ratio, main_height_ratio], hspace=0.03, wspace=0.05)
             ax1 = fig.add_subplot(gs[0, 1])
             ax2 = fig.add_subplot(gs[1, 1])
             ax_props = fig.add_subplot(gs[1, 2])  # Biophysical properties panel
@@ -293,13 +309,6 @@ def plot_heatmap(
             ax3 = fig.add_subplot(gs[1, 0])
             ax_props = None
     else:
-        if is_codon_heatmap:
-            avg_height_ratio = 0.75
-            main_height_ratio = 35
-        else:
-            avg_height_ratio = 1
-            main_height_ratio = 20
-            
         if show_props:
             # Add space for biophysical properties panel
             gs = GridSpec(2, 4, width_ratios=[35, 5, 1, 1], height_ratios=[avg_height_ratio, main_height_ratio], hspace=0.03, wspace=0.05)
@@ -453,6 +462,7 @@ def plot_tiled_heatmap(
     dpi: int = 300,
     tick_values: Optional[List[float]] = None,
     tick_labels: Optional[List[str]] = None,
+    row_avg: bool = True,
     title: Optional[str] = None,
     export_matrix: bool = False,
     biophysical_properties: bool = False,
@@ -490,6 +500,8 @@ def plot_tiled_heatmap(
         Custom colorbar tick values
     tick_labels : Optional[List[str]]
         Custom colorbar tick labels
+    row_avg : bool, optional
+        Whether to include the positional-average subplot row, default True
     title : Optional[str]
         Custom heatmap title
     export_matrix : bool, optional
@@ -585,39 +597,56 @@ def plot_tiled_heatmap(
         plot_matrix = plot_matrix.replace('WT', np.nan)
     plot_matrix = plot_matrix.apply(pd.to_numeric, errors='coerce')
     position_labels = global_positions
+    col_avg_df = make_col_avg_df(plot_matrix)
     
-    # Set figure size based on matrix dimensions
-    size_presets = {
-        'small': (12, 8),
-        'medium': (16, 10),
-        'large': (20, 12)
-    }
-    figsize = size_presets.get(fig_size, size_presets['large'])
-    
-    # Adjust figure width based on number of positions
+    num_rows = len(plot_matrix.index)
+    is_codon_heatmap = _is_codon_heatmap(num_rows)
+    is_aa_heatmap = _is_aa_heatmap(num_rows)
     n_positions = len(position_labels)
-    n_rows = len(plot_matrix.index)
-    if n_positions > 100:
-        figsize = (max(20, n_positions * 0.2), figsize[1])
-    # Increase height for large row counts so labels/cells remain readable.
-    figsize = (figsize[0], max(figsize[1], n_rows * 0.33))
+    width = round(max(12.0, n_positions * 0.2))
+    fixed_height = 22 if is_codon_heatmap else 12
+    figsize = (width, fixed_height)
     
     # Create figure
     facecolor = 'none' if transparent else 'white'
     fig = plt.figure(figsize=figsize, facecolor=facecolor)
     
+    avg_height_ratio, main_height_ratio = _avg_main_height_ratios(
+        row_avg=row_avg,
+        is_codon_heatmap=is_codon_heatmap,
+    )
+    grid_rows = 1
+    grid_cols = 1
+    if row_avg:
+        grid_rows += 1
     if biophysical_properties:
-        # Create gridspec with biophysical properties panel
-        gs = GridSpec(1, 2, figure=fig, width_ratios=[0.98, 0.02], wspace=0.01)
-        ax_heatmap = fig.add_subplot(gs[0, 0])
-        ax_props = fig.add_subplot(gs[0, 1])
-    else:
-        ax_heatmap = fig.add_subplot(111)
+        grid_cols += 1
+    height_ratios = [avg_height_ratio, main_height_ratio] if row_avg else [main_height_ratio]
+    width_ratios = [0.98, 0.02] if biophysical_properties else [1]
+
+    gs_kwargs = {
+        "figure": fig,
+        "height_ratios": height_ratios,
+        "width_ratios": width_ratios,
+    }
+    if row_avg:
+        gs_kwargs["hspace"] = 0.03
+    if biophysical_properties:
+        gs_kwargs["wspace"] = 0.01
+
+    gs = GridSpec(grid_rows, grid_cols, **gs_kwargs)
+
+    heatmap_row = 1 if row_avg else 0
+    ax_avg = fig.add_subplot(gs[0, 0]) if row_avg else None
+    ax_heatmap = fig.add_subplot(gs[heatmap_row, 0])
+    ax_props = fig.add_subplot(gs[heatmap_row, 1]) if biophysical_properties else None
     
     # Create heatmap with explicit clipping so colorbar doesn't show over/under caps.
     matrix_min = float(np.nanmin(plot_matrix.values))
     matrix_max = float(np.nanmax(plot_matrix.values))
     norm = plt.Normalize(vmin=matrix_min, vmax=matrix_max, clip=True)
+    if ax_avg is not None:
+        sns.heatmap(col_avg_df, annot=False, cmap='magma', cbar=False, ax=ax_avg, norm=norm)
     im = ax_heatmap.imshow(
         plot_matrix.values,
         aspect='auto',
@@ -641,9 +670,8 @@ def plot_tiled_heatmap(
     
     # Set ticks and labels
     # Show position labels every 5 residues with larger font for readability.
-    is_aa_like_heatmap = len(plot_matrix.index) <= 25
-    xtick_size = 24 if is_aa_like_heatmap else 22
-    ytick_size = 22 if is_aa_like_heatmap else 20
+    xtick_size = 24 if is_aa_heatmap else 22
+    ytick_size = 22 if is_aa_heatmap else 20
     tick_step = 5
     tick_indices = list(range(0, len(position_labels), tick_step))
     if (len(position_labels) - 1) not in tick_indices:
@@ -657,7 +685,7 @@ def plot_tiled_heatmap(
     divider = make_axes_locatable(ax_heatmap)
     cax = divider.append_axes("right", size="3%", pad=0.08)
     cbar = plt.colorbar(im, cax=cax)
-    cbar_label_size = 24 if len(plot_matrix.index) >= 60 else (22 if is_aa_like_heatmap else 18)
+    cbar_label_size = 24 if len(plot_matrix.index) >= 60 else (22 if is_aa_heatmap else 18)
     if tick_values and tick_labels:
         in_range = [
             (float(v), str(lbl))
@@ -690,12 +718,12 @@ def plot_tiled_heatmap(
 
     if title:
         title_text = title if "\n" in title else title.replace(" (", "\n(", 1)
-        title_size = 34 if is_aa_like_heatmap else 30
+        title_size = 34 if is_aa_heatmap else 30
         ax_heatmap.set_title(_title_with_bold_first_line(title_text), fontsize=title_size, pad=24)
     else:
         method = batch_config.batch_normalization_method
         n_exp = len(experiments)
-        title_size = 34 if is_aa_like_heatmap else 30
+        title_size = 34 if is_aa_heatmap else 30
         ax_heatmap.set_title(
             _title_with_bold_first_line(
                 f'Combined Activity Scores\n({method} normalization, {n_exp} experiments)'
@@ -705,9 +733,15 @@ def plot_tiled_heatmap(
         )
     
     # Set axis labels
-    axis_label_size = 36 if is_aa_like_heatmap else (32 if len(plot_matrix.index) >= 60 else 26)
+    axis_label_size = 36 if is_aa_heatmap else (32 if len(plot_matrix.index) >= 60 else 26)
     ax_heatmap.set_xlabel('Position', fontsize=axis_label_size)
     ax_heatmap.set_ylabel('Amino Acid', fontsize=axis_label_size)
+    if ax_avg is not None:
+        ax_avg.set_ylabel('Avg', fontsize=20, labelpad=20, ha='center', rotation=0)
+        avg_label = ax_avg.yaxis.get_label()
+        avg_label.set_verticalalignment('center')
+        ax_avg.set_xticks([])
+        ax_avg.set_yticks([])
     
     # Export matrix data if requested
     if export_matrix and output:

--- a/sortscore/visualization/heatmaps.py
+++ b/sortscore/visualization/heatmaps.py
@@ -536,7 +536,7 @@ def plot_tiled_heatmap(
     
     batch_to_experiment = {}
     for i, experiment in enumerate(experiments, 1):
-        batch_name = f'experiment{i}'
+        batch_name = f'tile{i}'
         batch_to_experiment[batch_name] = experiment
         position_mapping[batch_name] = {
             'min_pos': experiment.min_pos,

--- a/sortscore/visualization/heatmaps.py
+++ b/sortscore/visualization/heatmaps.py
@@ -141,7 +141,6 @@ def plot_heatmap(
     export_matrix: bool = False,
     biophysical_properties: bool = False,
     export_positional_averages: bool = False,
-    suffix: Optional[str] = None,
     heatmap_basename: str = "heatmap",
     matrix_basename: str = "heatmap_matrix",
     transparent: bool = True
@@ -185,8 +184,6 @@ def plot_heatmap(
         If True, show biophysical properties panel beside the heatmap.
     export_positional_averages : bool, default False
         If True, export positional averages with hex colors to CSV for protein structure visualization.
-    suffix : str, optional
-        Suffix to append to output filenames for consistent naming.
     heatmap_basename : str, optional
         Base name for exported heatmap image (default: ``"heatmap"``).
     matrix_basename : str, optional
@@ -228,10 +225,7 @@ def plot_heatmap(
         new_columns = [str(i) for i in range(experiment.min_pos, experiment.min_pos + experiment.num_aa)]
         matrix_for_export.columns = new_columns
 
-        if suffix:
-            matrix_output = f"{output_prefix}_{matrix_basename}_{suffix}.csv"
-        else:
-            matrix_output = f"{output_prefix}_{matrix_basename}.csv"
+        matrix_output = f"{output_prefix}_{matrix_basename}.csv"
         matrix_for_export.to_csv(matrix_output)
         logger.info(f"Heatmap matrix saved to {matrix_output}")
     
@@ -239,10 +233,7 @@ def plot_heatmap(
     if export_positional_averages:
         # Use the same normalization and colormap as the main heatmap for exact color matching
         averages_colors = generate_position_avg_colors(heatmap_df, colormap='magma', norm=norm, cmap=cmap)
-        if suffix:
-            averages_output = f"{output_prefix}_positional_averages_{suffix}.csv"
-        else:
-            averages_output = f"{output_prefix}_positional_averages.csv"
+        averages_output = f"{output_prefix}_positional_averages.csv"
         averages_colors.to_csv(averages_output, index=False)
         logger.info(f"Positional averages with colors saved to {averages_output}")
 
@@ -439,10 +430,7 @@ def plot_heatmap(
 
     # Save or show plot
     if export_heatmap:
-        if suffix:
-            heatmap_output = f"{output_prefix}_{heatmap_basename}_{suffix}.{fig_format}"
-        else:
-            heatmap_output = f"{output_prefix}_{heatmap_basename}.{fig_format}"
+        heatmap_output = f"{output_prefix}_{heatmap_basename}.{fig_format}"
         facecolor = 'none' if transparent else 'white'
         plt.savefig(heatmap_output, dpi=dpi, format=fig_format, facecolor=facecolor, edgecolor='none')
         logger.info(f"Heatmap plot saved to {heatmap_output}")

--- a/tests/integration/test_cli_scoring.py
+++ b/tests/integration/test_cli_scoring.py
@@ -3,7 +3,6 @@ import tempfile
 import sys
 from pathlib import Path
 import json
-from datetime import datetime
 import pandas as pd
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -11,9 +10,18 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 
 def test_sortscore_cli_runs_and_outputs(config_dict, cleanup_outputs, isolated_runtime_env):
     """Test scoring CLI run produces fresh outputs for this invocation."""
-    expected_suffix = datetime.now().strftime("%Y%m%d")
     output_root = (REPO_ROOT / "_test_outputs").resolve()
-    pre_existing = set(output_root.rglob("test_experiment_*"))
+    expected_files = [
+        output_root / "scores" / "test_experiment_dna_scores.csv",
+        output_root / "scores" / "test_experiment_aa_scores.csv",
+        output_root / "scores" / "test_experiment_dna_stats.json",
+        output_root / "scores" / "test_experiment_aa_stats.json",
+        output_root / "figures" / "test_experiment_aa_heatmap.png",
+        output_root / "figures" / "test_experiment_aa_heatmap_matrix.csv",
+    ]
+    for path in expected_files:
+        if path.exists():
+            path.unlink()
     with tempfile.TemporaryDirectory(prefix="sortscore_cfg_") as cfg_tmp:
         run_cfg = dict(config_dict)
         run_cfg["output_dir"] = str(output_root)
@@ -41,23 +49,12 @@ def test_sortscore_cli_runs_and_outputs(config_dict, cleanup_outputs, isolated_r
         assert result.returncode == 0, f"CLI failed: {result.stderr}"
 
         assert output_root.exists(), f"Expected output directory to exist: {output_root}"
-        created = set(output_root.rglob("test_experiment_*")) - pre_existing
-        expected_files = [
-            output_root / "scores" / f"test_experiment_dna_scores_{expected_suffix}.csv",
-            output_root / "scores" / f"test_experiment_aa_scores_{expected_suffix}.csv",
-            output_root / "scores" / f"test_experiment_dna_stats_{expected_suffix}.json",
-            output_root / "scores" / f"test_experiment_aa_stats_{expected_suffix}.json",
-            output_root / "figures" / f"test_experiment_aa_heatmap_{expected_suffix}.png",
-            output_root / "figures" / f"test_experiment_aa_heatmap_matrix_{expected_suffix}.csv",
-        ]
         missing = [str(p) for p in expected_files if not p.exists()]
         assert not missing, f"Missing expected fresh output files:\n" + "\n".join(missing)
-        assert created, "Expected scoring run to create output artifacts"
 
 
 def test_sortscore_cli_multitile_writes_tile_scores(config_dict, batch_config_dict, isolated_runtime_env):
     """Tiled scoring should emit per-tile score outputs."""
-    expected_suffix = datetime.now().strftime("%Y%m%d")
     workdir = (REPO_ROOT / "_test_outputs").resolve()
     with tempfile.TemporaryDirectory(prefix="sortscore_multitile_cfg_") as cfg_tmp:
         output_root = workdir
@@ -69,7 +66,7 @@ def test_sortscore_cli_multitile_writes_tile_scores(config_dict, batch_config_di
             for entry in batch_config_dict["experiments"]
         }
         expected_tile_files = {
-            tile: tile_dirs[tile] / "scores" / f"test_multitile_tile{tile}_aa_scores_{expected_suffix}.csv"
+            tile: tile_dirs[tile] / "scores" / f"test_multitile_tile{tile}_aa_scores.csv"
             for tile in (1, 2)
         }
         for p in expected_tile_files.values():
@@ -112,7 +109,7 @@ def test_sortscore_cli_multitile_writes_tile_scores(config_dict, batch_config_di
         for tile in (1, 2):
             tile_scores = expected_tile_files[tile]
             assert tile_scores.exists(), f"Missing tile score file: {tile_scores}"
-            tile_fig = tile_dirs[tile] / "figures" / f"test_multitile_tile{tile}_aa_heatmap_{expected_suffix}.png"
+            tile_fig = tile_dirs[tile] / "figures" / f"test_multitile_tile{tile}_aa_heatmap.png"
             assert tile_fig.exists(), f"Missing tile figure file: {tile_fig}"
 
         # Distinct tile inputs should not produce identical score tables.

--- a/tests/regression/test_scoring_regression.py
+++ b/tests/regression/test_scoring_regression.py
@@ -1,5 +1,4 @@
 import json
-from datetime import datetime
 from pathlib import Path
 import subprocess
 import sys
@@ -48,9 +47,8 @@ def _assert_aa_regression_subset(output_path, fixture_path):
 
 def test_sortscore_cli_aa_scores_regression_subset(config_dict, tmp_path, isolated_runtime_env):
     """AA score output should remain stable for an example subset of variants."""
-    expected_suffix = datetime.now().strftime("%Y%m%d")
     output_root = (REPO_ROOT / "_test_outputs").resolve()
-    output_path = output_root / "scores" / f"test_experiment_regression_aa_scores_{expected_suffix}.csv"
+    output_path = output_root / "scores" / "test_experiment_regression_aa_scores.csv"
     if output_path.exists():
         output_path.unlink()
 
@@ -95,11 +93,10 @@ def test_sortscore_cli_multitile_tile2_regression_subset(
         entry_cfg["output_dir"] = str(Path(entry_cfg["output_dir"]).resolve())
         run_cfg["experiments"].append(entry_cfg)
 
-    expected_suffix = datetime.now().strftime("%Y%m%d")
     setup_path = REPO_ROOT / "demo_data" / "combined_experiment_setup.csv"
     tile2_entry = next(entry for entry in run_cfg["experiments"] if int(entry["tile"]) == 2)
     tile2_output_dir = Path(tile2_entry["output_dir"]).resolve()
-    output_path = tile2_output_dir / "scores" / f"test_multitile_regression_tile2_aa_scores_{expected_suffix}.csv"
+    output_path = tile2_output_dir / "scores" / "test_multitile_regression_tile2_aa_scores.csv"
     if output_path.exists():
         output_path.unlink()
 


### PR DESCRIPTION
This resolves:
- Batch heatmap (multi-tile) lacking positional average row
- Batch mode not outputting aa_scores file
- Date based suffix causing filesystem clutter

It additionally addresses:
- redundancies and lack of readability in plotting functions
- consistent "tile" terminology instead of "experiment" for batch naming